### PR TITLE
updated: walljump trajectory, player speed

### DIFF
--- a/Assets/Prefabs/Entities/Player/Player.prefab
+++ b/Assets/Prefabs/Entities/Player/Player.prefab
@@ -1,58 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &214549312586141809
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8031412989564038786}
-  - component: {fileID: 2026230133116130744}
-  m_Layer: 3
-  m_Name: RightCheck
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8031412989564038786
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 214549312586141809}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.6962, y: 0, z: 0}
-  m_LocalScale: {x: 0.44747186, y: 0.28582, z: 0.28582}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1875896232990815028}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &2026230133116130744
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 214549312586141809}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &978219371158355710
 GameObject:
   m_ObjectHideFlags: 0
@@ -162,59 +109,6 @@ CapsuleCollider:
   m_Radius: 0.5
   m_Height: 2
   m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!1 &1004233673575262410
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4137483457119029506}
-  - component: {fileID: 4167372778689279533}
-  m_Layer: 3
-  m_Name: LeftCheck
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4137483457119029506
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1004233673575262410}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.6962, y: 0, z: 0}
-  m_LocalScale: {x: 0.44747186, y: 0.28582, z: 0.28582}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1875896232990815028}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &4167372778689279533
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1004233673575262410}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1291128166782455673
 GameObject:
@@ -453,9 +347,7 @@ Transform:
   m_LocalPosition: {x: 0, y: -0.368, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4137483457119029506}
-  - {fileID: 8031412989564038786}
+  m_Children: []
   m_Father: {fileID: 5567704814126278728}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7522375978854383406
@@ -673,8 +565,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7912379d51e3e7e44869c9b7093d314a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  leftCheck: {fileID: 4137483457119029506}
-  rightCheck: {fileID: 8031412989564038786}
   wallCheckOrigin: {fileID: 1875896232990815028}
   wallLayers:
     serializedVersion: 2

--- a/Assets/Prefabs/Entities/Player/Player.prefab
+++ b/Assets/Prefabs/Entities/Player/Player.prefab
@@ -1,5 +1,58 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &214549312586141809
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8031412989564038786}
+  - component: {fileID: 2026230133116130744}
+  m_Layer: 3
+  m_Name: RightCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8031412989564038786
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 214549312586141809}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.6962, y: 0, z: 0}
+  m_LocalScale: {x: 0.44747186, y: 0.28582, z: 0.28582}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1875896232990815028}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2026230133116130744
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 214549312586141809}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &978219371158355710
 GameObject:
   m_ObjectHideFlags: 0
@@ -109,6 +162,59 @@ CapsuleCollider:
   m_Radius: 0.5
   m_Height: 2
   m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1004233673575262410
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4137483457119029506}
+  - component: {fileID: 4167372778689279533}
+  m_Layer: 3
+  m_Name: LeftCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4137483457119029506
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1004233673575262410}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.6962, y: 0, z: 0}
+  m_LocalScale: {x: 0.44747186, y: 0.28582, z: 0.28582}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1875896232990815028}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4167372778689279533
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1004233673575262410}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1291128166782455673
 GameObject:
@@ -328,7 +434,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1875896232990815028}
-  - component: {fileID: 9047428742248276699}
   m_Layer: 3
   m_Name: WallCheck
   m_TagString: Untagged
@@ -345,33 +450,14 @@ Transform:
   m_GameObject: {fileID: 7101349836560035275}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.8934562, y: 0.25, z: 0.25}
+  m_LocalPosition: {x: 0, y: -0.368, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 4137483457119029506}
+  - {fileID: 8031412989564038786}
   m_Father: {fileID: 5567704814126278728}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &9047428742248276699
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7101349836560035275}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &7522375978854383406
 GameObject:
   m_ObjectHideFlags: 0
@@ -536,7 +622,7 @@ MonoBehaviour:
   groundLayer:
     serializedVersion: 2
     m_Bits: 64
-  groundSpeed: 90
+  groundSpeed: 70
   airSpeed: 6
   jumpForce: 5
   airMultiplier: 0.8
@@ -587,10 +673,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7912379d51e3e7e44869c9b7093d314a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wallCheck: {fileID: 1875896232990815028}
+  leftCheck: {fileID: 4137483457119029506}
+  rightCheck: {fileID: 8031412989564038786}
+  wallCheckOrigin: {fileID: 1875896232990815028}
   wallLayers:
     serializedVersion: 2
     m_Bits: 256
+  orientation: {fileID: 5567704814126278728}
 --- !u!1 &8362820426947322467
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PrototypeMap.unity
+++ b/Assets/Scenes/PrototypeMap.unity
@@ -38510,9 +38510,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 128262756}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 138.43994, y: -230}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -235, y: 0}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1962351906
@@ -38569,7 +38569,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -40824,6 +40824,10 @@ PrefabInstance:
     - target: {fileID: 1634934622893517213, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5252524867374529993, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
+      propertyPath: groundSpeed
+      value: 70
       objectReference: {fileID: 0}
     - target: {fileID: 8142240636484815424, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/PrototypeMap.unity
+++ b/Assets/Scenes/PrototypeMap.unity
@@ -40791,7 +40791,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1634934622893517213, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.58
+      value: 1.38
       objectReference: {fileID: 0}
     - target: {fileID: 1634934622893517213, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -57,8 +57,8 @@ public class PlayerMovement : MonoBehaviour
     }
     void WallRun(float horizontal)
     {
-
-        if (Grounded())
+        float horizontalVelocity = Vector3.Scale(rb.linearVelocity, new Vector3(1,0,1)).magnitude; 
+        if (Grounded() || horizontalVelocity < wallRun.GetMinBuildUpVel())
         {
             wallRun.SetCanWallRun(false);
             wallRun.SetIsWallRunning(false);

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -66,8 +66,8 @@ public class PlayerMovement : MonoBehaviour
         }
 
         wallRun.SetCanWallRun(true);
-
-        if(wallRun.TouchingWall() && (horizontal != 0)){
+        int touchingWall = wallRun.IsTouchingWall();
+        if(touchingWall != 0 && (horizontal == touchingWall)){
             wallRun.WallRun();
             wallRun.SetIsWallRunning(true);
         }

--- a/Assets/Scripts/Player/PlayerWallRun.cs
+++ b/Assets/Scripts/Player/PlayerWallRun.cs
@@ -1,17 +1,21 @@
+using System;
 using UnityEngine;
 
 [RequireComponent(typeof(Rigidbody))]
 public class PlayerWallRun : MonoBehaviour
 {
-    const float UP_FORCE = 5f;
-    const float WALL_JUMP_FORCE = 15f;
-    
+    const float WALL_CHECK_DIST = 0.8f;
+    const float AWAy_FORCE = 5f;
+    const float UP_FORCE = 4f;
+    const float FORWARD_FORCE = 3f;
 
     bool canWallRun = true;
     bool isWallRunning = false;
-
-    [SerializeField] Transform wallCheck;
+    [SerializeField] Transform leftCheck;
+    [SerializeField] Transform rightCheck;
+    [SerializeField] Transform wallCheckOrigin;
     [SerializeField] LayerMask wallLayers;
+    [SerializeField] Transform orientation;
     Rigidbody rb;
 
     void Start()
@@ -19,14 +23,32 @@ public class PlayerWallRun : MonoBehaviour
         rb = GetComponent<Rigidbody>();
     }
 
-    public bool TouchingWall()
+    void FixedUpdate()
     {
-        return Physics.CheckBox(
-            wallCheck.position, 
-            wallCheck.GetComponent<BoxCollider>().size/2, 
-            wallCheck.rotation, 
+        Debug.DrawRay(wallCheckOrigin.position, orientation.right * WALL_CHECK_DIST, Color.red);
+        Debug.DrawRay(wallCheckOrigin.position, -orientation.right * WALL_CHECK_DIST, Color.red);
+    }
+
+    public int IsTouchingWall()
+    {
+        if(WallRayCast(-1).collider) return -1;
+        if(WallRayCast(1).collider) return 1;
+        return 0;
+    }
+    
+    RaycastHit WallRayCast(int dir)
+    {
+        Physics.Raycast(
+            wallCheckOrigin.position,
+            dir * orientation.right,
+            out RaycastHit hit,
+            WALL_CHECK_DIST,
             wallLayers
-        );
+        );    
+        
+        Debug.Log(hit.normal);
+
+        return hit;
     }
 
     public void WallRun()
@@ -37,8 +59,15 @@ public class PlayerWallRun : MonoBehaviour
 
     public void WallJump(Vector3 direction)
     {
-        rb.linearVelocity = Vector3.zero;
-        rb.AddForce(direction * WALL_JUMP_FORCE, ForceMode.Impulse);
+        
+        RaycastHit leftHit = WallRayCast(-1);
+        RaycastHit rightHit = WallRayCast(1);
+        
+        Vector3 wallNormal = leftHit.collider ? leftHit.normal : rightHit.normal;
+        
+        rb.AddForce(wallNormal * AWAy_FORCE, ForceMode.Impulse);
+        rb.AddForce(Vector3.up * UP_FORCE, ForceMode.Impulse);
+        rb.AddForce(direction * FORWARD_FORCE, ForceMode.Impulse);
     }
 
     public void SetCanWallRun(bool canWallRun)

--- a/Assets/Scripts/Player/PlayerWallRun.cs
+++ b/Assets/Scripts/Player/PlayerWallRun.cs
@@ -12,6 +12,7 @@ public class PlayerWallRun : MonoBehaviour
     bool canWallRun = true;
     bool isWallRunning = false;
 
+    [SerializeField] float minBuildUpVel;
     [SerializeField] Transform wallCheckOrigin;
     [SerializeField] LayerMask wallLayers;
     [SerializeField] Transform orientation;
@@ -22,7 +23,7 @@ public class PlayerWallRun : MonoBehaviour
         rb = GetComponent<Rigidbody>();
     }
 
-    void FixedUpdate()
+    void DrawWallCheck()
     {
         Debug.DrawRay(wallCheckOrigin.position, orientation.right * WALL_CHECK_DIST, Color.red);
         Debug.DrawRay(wallCheckOrigin.position, -orientation.right * WALL_CHECK_DIST, Color.red);
@@ -45,8 +46,6 @@ public class PlayerWallRun : MonoBehaviour
             wallLayers
         );    
         
-        Debug.Log(hit.normal);
-
         return hit;
     }
 
@@ -86,5 +85,10 @@ public class PlayerWallRun : MonoBehaviour
     public bool GetIsWallRunning()
     {
         return isWallRunning;
+    }
+
+    public float GetMinBuildUpVel()
+    {
+        return minBuildUpVel;
     }
 }

--- a/Assets/Scripts/Player/PlayerWallRun.cs
+++ b/Assets/Scripts/Player/PlayerWallRun.cs
@@ -11,8 +11,7 @@ public class PlayerWallRun : MonoBehaviour
 
     bool canWallRun = true;
     bool isWallRunning = false;
-    [SerializeField] Transform leftCheck;
-    [SerializeField] Transform rightCheck;
+
     [SerializeField] Transform wallCheckOrigin;
     [SerializeField] LayerMask wallLayers;
     [SerializeField] Transform orientation;


### PR DESCRIPTION
* walljump no longer resets player speed and its trajectory launches player away from wall + up at fixed force
* player can influence arc by facing the direction they want to jump
* player walk speed reduced