### PR TITLE
Movement polish

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,11 +60,11 @@
         "*.asset": "yaml",
         "*.meta": "yaml",
         "*.prefab": "yaml",
-        "*.unity": "yaml",
+        "*.unity": "yaml"
     },
     "explorer.fileNesting.enabled": true,
     "explorer.fileNesting.patterns": {
-        "*.sln": "*.csproj",
+        "*.sln": "*.csproj"
     },
     "dotnet.defaultSolution": "project-empty-server.sln"
 }

--- a/Assets/Animations/Player.meta
+++ b/Assets/Animations/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c065605f2e4ce8749b42ca75ee957282
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Player/Orientation.meta
+++ b/Assets/Animations/Player/Orientation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f7c1f069698eb464984dd2ec2b962e23
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Player/Orientation/AirCrouch.anim
+++ b/Assets/Animations/Player/Orientation/AirCrouch.anim
@@ -20,23 +20,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 0, y: 0.6359999, z: 0}
-        inSlope: {x: 0, y: 0, z: 0}
-        outSlope: {x: 0, y: 0, z: 0}
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    path: CameraHolder
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: {x: 0, y: 0, z: 0}
+        value: {x: 0, y: 0.3506, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -44,7 +28,7 @@ AnimationClip:
         inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: {x: 0, y: 0.3506, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
@@ -61,7 +45,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 0, y: -0.908, z: 0}
+        value: {x: 0, y: -0.254, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -69,7 +53,7 @@ AnimationClip:
         inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: {x: 0, y: -0.254, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
@@ -87,7 +71,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 1, y: 1, z: 1}
+        value: {x: 1, y: 0.6493903, z: 1}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -95,7 +79,7 @@ AnimationClip:
         inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: {x: 1, y: 0.6493903, z: 1}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
@@ -143,22 +127,13 @@ AnimationClip:
       isPPtrCurve: 0
       isIntCurve: 0
       isSerializeReferenceCurve: 0
-    - serializedVersion: 2
-      path: 1022213160
-      attribute: 1
-      script: {fileID: 0}
-      typeID: 4
-      customType: 0
-      isPPtrCurve: 0
-      isIntCurve: 0
-      isSerializeReferenceCurve: 0
     pptrCurveMapping: []
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.11666667
+    m_StopTime: 0.016666668
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -187,71 +162,8 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalPosition.x
-    path: CameraHolder
-    classID: 4
-    script: {fileID: 0}
-    flags: 0
-  - serializedVersion: 2
-    curve:
-      serializedVersion: 2
-      m_Curve:
       - serializedVersion: 3
-        time: 0
-        value: 0.6359999
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalPosition.y
-    path: CameraHolder
-    classID: 4
-    script: {fileID: 0}
-    flags: 0
-  - serializedVersion: 2
-    curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalPosition.z
-    path: CameraHolder
-    classID: 4
-    script: {fileID: 0}
-    flags: 0
-  - serializedVersion: 2
-    curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: 0
         inSlope: 0
         outSlope: 0
@@ -273,7 +185,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0
+        value: 0.3506
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -281,7 +193,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: 0.3506
         inSlope: 0
         outSlope: 0
@@ -311,7 +223,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: 0
         inSlope: 0
         outSlope: 0
@@ -341,7 +253,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: 1
         inSlope: 0
         outSlope: 0
@@ -363,7 +275,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 1
+        value: 0.6493903
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -371,7 +283,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: 0.6493903
         inSlope: 0
         outSlope: 0
@@ -401,7 +313,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: 1
         inSlope: 0
         outSlope: 0
@@ -431,7 +343,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: 0
         inSlope: 0
         outSlope: 0
@@ -453,7 +365,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -0.908
+        value: -0.254
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -461,7 +373,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: -0.254
         inSlope: 0
         outSlope: 0
@@ -491,7 +403,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.11666667
+        time: 0.016666668
         value: 0
         inSlope: 0
         outSlope: 0

--- a/Assets/Animations/Player/Orientation/AirCrouch.anim
+++ b/Assets/Animations/Player/Orientation/AirCrouch.anim
@@ -1,0 +1,513 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AirCrouch
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0.6359999, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: CameraHolder
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 0, y: 0.3506, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: -0.908, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 0, y: -0.254, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: GroundCheck
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 1, y: 1, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 1, y: 0.6493903, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 1923299162
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 3
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 1022213160
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.11666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.6359999
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0.3506
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0.6493903
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: GroundCheck
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: -0.908
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: -0.254
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: GroundCheck
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: GroundCheck
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Player/Orientation/AirCrouch.anim.meta
+++ b/Assets/Animations/Player/Orientation/AirCrouch.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fb766d329458ff47b8cbd3e51c451ad
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Player/Orientation/AirStandUp.anim
+++ b/Assets/Animations/Player/Orientation/AirStandUp.anim
@@ -1,0 +1,549 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AirStandUp
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0.3506, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0.6359999, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 0, y: 0.6359999, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: CameraHolder
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: -0.254, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 0, y: -0.908, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: GroundCheck
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 1, y: 0.6493903, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 1, y: 1, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 1923299162
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 3
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 1022213160
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.11666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.3506
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.6493903
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.6359999
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0.6359999
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: GroundCheck
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: -0.254
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: -0.908
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: GroundCheck
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: GroundCheck
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Player/Orientation/AirStandUp.anim.meta
+++ b/Assets/Animations/Player/Orientation/AirStandUp.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f071f11c5d2957a49b02edcb646f9f89
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Player/Orientation/GroundCrouch.anim
+++ b/Assets/Animations/Player/Orientation/GroundCrouch.anim
@@ -1,0 +1,425 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GroundCrouch
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0.6359999, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 0, y: 0.029, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: CameraHolder
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 0, y: -0.3506, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 1, y: 1, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 1, y: 0.64939034, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 1022213160
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 3
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.11666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.6359999
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0.029
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: -0.3506
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0.64939034
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Player/Orientation/GroundCrouch.anim.meta
+++ b/Assets/Animations/Player/Orientation/GroundCrouch.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff0810a0c993afe4bbba842f8acc4255
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Player/Orientation/GroundSlide.anim
+++ b/Assets/Animations/Player/Orientation/GroundSlide.anim
@@ -6,7 +6,7 @@ AnimationClip:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: GroundCrouch
+  m_Name: GroundSlide
   serializedVersion: 7
   m_Legacy: 0
   m_Compressed: 0
@@ -20,7 +20,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 0, y: 0.029, z: 0}
+        value: {x: 0, y: -0.5461, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -29,32 +29,7 @@ AnimationClip:
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
         time: 0.016666668
-        value: {x: 0, y: 0.029, z: 0}
-        inSlope: {x: 0, y: 0, z: 0}
-        outSlope: {x: 0, y: 0, z: 0}
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    path: CameraHolder
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: {x: 0, y: -0.3506, z: 0}
-        inSlope: {x: 0, y: 0, z: 0}
-        outSlope: {x: 0, y: 0, z: 0}
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-      - serializedVersion: 3
-        time: 0.016666668
-        value: {x: 0, y: -0.3506, z: 0}
+        value: {x: 0, y: -0.5461, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -65,13 +40,12 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     path: Capsule
-  m_ScaleCurves:
   - curve:
       serializedVersion: 2
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 1, y: 0.64939034, z: 1}
+        value: {x: 0, y: -0.963, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -80,7 +54,33 @@ AnimationClip:
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
         time: 0.016666668
-        value: {x: 1, y: 0.64939034, z: 1}
+        value: {x: 0, y: -0.963, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: CameraHolder/Camera
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 1, y: 0.4539, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.016666668
+        value: {x: 1, y: 0.4539, z: 1}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -101,7 +101,7 @@ AnimationClip:
   m_ClipBindingConstant:
     genericBindings:
     - serializedVersion: 2
-      path: 1022213160
+      path: 232101919
       attribute: 1
       script: {fileID: 0}
       typeID: 4
@@ -110,7 +110,7 @@ AnimationClip:
       isIntCurve: 0
       isSerializeReferenceCurve: 0
     - serializedVersion: 2
-      path: 232101919
+      path: 3523755033
       attribute: 1
       script: {fileID: 0}
       typeID: 4
@@ -175,96 +175,6 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_LocalPosition.x
-    path: CameraHolder
-    classID: 4
-    script: {fileID: 0}
-    flags: 0
-  - serializedVersion: 2
-    curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0.029
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.016666668
-        value: 0.029
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalPosition.y
-    path: CameraHolder
-    classID: 4
-    script: {fileID: 0}
-    flags: 0
-  - serializedVersion: 2
-    curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.016666668
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalPosition.z
-    path: CameraHolder
-    classID: 4
-    script: {fileID: 0}
-    flags: 0
-  - serializedVersion: 2
-    curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.016666668
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalPosition.x
     path: Capsule
     classID: 4
     script: {fileID: 0}
@@ -275,7 +185,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -0.3506
+        value: -0.5461
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -284,7 +194,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.016666668
-        value: -0.3506
+        value: -0.5461
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -365,7 +275,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.64939034
+        value: 0.4539
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -374,7 +284,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.016666668
-        value: 0.64939034
+        value: 0.4539
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -416,6 +326,96 @@ AnimationClip:
       m_RotationOrder: 4
     attribute: m_LocalScale.z
     path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.016666668
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: CameraHolder/Camera
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: -0.963
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.016666668
+        value: -0.963
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: CameraHolder/Camera
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.016666668
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: CameraHolder/Camera
     classID: 4
     script: {fileID: 0}
     flags: 0

--- a/Assets/Animations/Player/Orientation/GroundSlide.anim.meta
+++ b/Assets/Animations/Player/Orientation/GroundSlide.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3be7011ef2688db43a836a2ae26af94d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Player/Orientation/GroundStandUp.anim
+++ b/Assets/Animations/Player/Orientation/GroundStandUp.anim
@@ -1,0 +1,425 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GroundStandUp
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0.029, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 0, y: 0.6359999, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: CameraHolder
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: -0.3506, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 1, y: 0.6493903, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.11666667
+        value: {x: 1, y: 1, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 1022213160
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 3
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.11666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.029
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0.6359999
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: -0.3506
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.6493903
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.11666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Player/Orientation/GroundStandUp.anim.meta
+++ b/Assets/Animations/Player/Orientation/GroundStandUp.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce3130571860da541911017ea755470b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Player/Orientation/Idle.anim
+++ b/Assets/Animations/Player/Orientation/Idle.anim
@@ -1,0 +1,317 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0.6359999, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: CameraHolder
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 1, y: 1, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Capsule
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 1022213160
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 232101919
+      attribute: 3
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.6359999
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: CameraHolder
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.x
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.y
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.z
+    path: Capsule
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Player/Orientation/Idle.anim.meta
+++ b/Assets/Animations/Player/Orientation/Idle.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fabde809919e38049973ba2e43307dea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Player/Orientation/PlayerOrientation.controller
+++ b/Assets/Animations/Player/Orientation/PlayerOrientation.controller
@@ -1,30 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1101 &-8287197612780397298
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: AirStandUp
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -3668854303707722321}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1102 &-6959265476885965635
 AnimatorState:
   serializedVersion: 6
@@ -36,8 +11,9 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: 3337106957514733274}
-  - {fileID: -5451700442127743903}
+  - {fileID: -4914001862203350669}
+  - {fileID: 5665668721513457468}
+  - {fileID: -4707851220654778605}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -53,7 +29,7 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &-5451700442127743903
+--- !u!1101 &-4914001862203350669
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -62,18 +38,105 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: AirCrouch
+    m_ConditionEvent: CrouchPressed
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: Grounded
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: Sliding
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 3997618425405177691}
+  m_DstState: {fileID: 8266268976970671112}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0
+  m_TransitionDuration: 0.1
   m_TransitionOffset: 0
   m_ExitTime: 0.75
   m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-4707851220654778605
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Sliding
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: Grounded
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2465076779379803191}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.13
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-4648518239752711752
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: CrouchPressed
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6959265476885965635}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.1
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-4408986984054651228
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Sliding
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: Grounded
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2465076779379803191}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.1
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -89,26 +152,29 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -6959265476885965635}
-    m_Position: {x: 30, y: 130, z: 0}
+    m_Position: {x: 0, y: 150, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 8266268976970671112}
-    m_Position: {x: 430, y: 320, z: 0}
+    m_Position: {x: 50, y: 590, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 912697715850440543}
-    m_Position: {x: 430, y: 120, z: 0}
+    m_Position: {x: 150, y: 30, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 3997618425405177691}
-    m_Position: {x: 260, y: -160, z: 0}
+    m_Position: {x: 430, y: 280, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -3668854303707722321}
-    m_Position: {x: 340, y: -20, z: 0}
+    m_Position: {x: 330, y: -20, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -2465076779379803191}
+    m_Position: {x: 370, y: 590, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 60, y: -120, z: 0}
-  m_EntryPosition: {x: 40, y: 410, z: 0}
+  m_EntryPosition: {x: -110, y: 410, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -6959265476885965635}
@@ -122,8 +188,7 @@ AnimatorState:
   m_Name: AirStandUp
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 1909694414419890774}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -139,28 +204,34 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &-3341832075182906135
-AnimatorStateTransition:
+--- !u!1102 &-2465076779379803191
+AnimatorState:
+  serializedVersion: 6
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -6959265476885965635}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
+  m_Name: GroundSlide
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 8869372357425199926}
+  - {fileID: 960849644707303155}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 3be7011ef2688db43a836a2ae26af94d, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -170,31 +241,19 @@ AnimatorController:
   m_Name: PlayerOrientation
   serializedVersion: 5
   m_AnimatorParameters:
-  - m_Name: GroundCrouch
-    m_Type: 9
+  - m_Name: Grounded
+    m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
-  - m_Name: GroundStandUp
-    m_Type: 9
+  - m_Name: CrouchPressed
+    m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
-  - m_Name: AirCrouch
-    m_Type: 9
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  - m_Name: AirStandUp
-    m_Type: 9
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  - m_Name: AirCrouched
+  - m_Name: Sliding
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -223,8 +282,7 @@ AnimatorState:
   m_Name: GroundStandUp
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -3341832075182906135}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -240,29 +298,7 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &1909694414419890774
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -6959265476885965635}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &3337106957514733274
+--- !u!1101 &960849644707303155
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -271,7 +307,10 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: GroundCrouch
+    m_ConditionEvent: CrouchPressed
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: Sliding
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 8266268976970671112}
@@ -279,9 +318,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0
+  m_TransitionDuration: 0.1
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_ExitTime: 0
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -298,7 +337,8 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: -8287197612780397298}
+  - {fileID: -4648518239752711752}
+  - {fileID: -4408986984054651228}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -314,7 +354,7 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &5557577802593760890
+--- !u!1101 &5665668721513457468
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -323,18 +363,21 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: GroundStandUp
+    m_ConditionEvent: CrouchPressed
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: Grounded
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 912697715850440543}
+  m_DstState: {fileID: 3997618425405177691}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0
+  m_TransitionDuration: 0.1
   m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 1
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -350,7 +393,7 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: 5557577802593760890}
+  - {fileID: 8571342693605256274}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -366,3 +409,56 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &8571342693605256274
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: CrouchPressed
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6959265476885965635}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.1
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &8869372357425199926
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: CrouchPressed
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: Sliding
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6959265476885965635}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.13
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/Assets/Animations/Player/Orientation/PlayerOrientation.controller
+++ b/Assets/Animations/Player/Orientation/PlayerOrientation.controller
@@ -1,0 +1,368 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-8287197612780397298
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: AirStandUp
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -3668854303707722321}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-6959265476885965635
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 3337106957514733274}
+  - {fileID: -5451700442127743903}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: fabde809919e38049973ba2e43307dea, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-5451700442127743903
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: AirCrouch
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3997618425405177691}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1107 &-3866552355953338091
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -6959265476885965635}
+    m_Position: {x: 30, y: 130, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 8266268976970671112}
+    m_Position: {x: 430, y: 320, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 912697715850440543}
+    m_Position: {x: 430, y: 120, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3997618425405177691}
+    m_Position: {x: 260, y: -160, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -3668854303707722321}
+    m_Position: {x: 340, y: -20, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 60, y: -120, z: 0}
+  m_EntryPosition: {x: 40, y: 410, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -6959265476885965635}
+--- !u!1102 &-3668854303707722321
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AirStandUp
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 1909694414419890774}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: f071f11c5d2957a49b02edcb646f9f89, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-3341832075182906135
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6959265476885965635}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PlayerOrientation
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: GroundCrouch
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: GroundStandUp
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: AirCrouch
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: AirStandUp
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: AirCrouched
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -3866552355953338091}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &912697715850440543
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GroundStandUp
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -3341832075182906135}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: ce3130571860da541911017ea755470b, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &1909694414419890774
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6959265476885965635}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &3337106957514733274
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: GroundCrouch
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8266268976970671112}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &3997618425405177691
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AirCrouch
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -8287197612780397298}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 1fb766d329458ff47b8cbd3e51c451ad, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &5557577802593760890
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: GroundStandUp
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 912697715850440543}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &8266268976970671112
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GroundCrouch
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5557577802593760890}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: ff0810a0c993afe4bbba842f8acc4255, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Animations/Player/Orientation/PlayerOrientation.controller.meta
+++ b/Assets/Animations/Player/Orientation/PlayerOrientation.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 781abe7ce940f0d48be4f53db08fb07e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Entities/Player/Player.prefab
+++ b/Assets/Prefabs/Entities/Player/Player.prefab
@@ -319,7 +319,6 @@ MonoBehaviour:
   orientation: {fileID: 5567704814126278728}
   mouseSensitivity: 300
   verticalClamp: 90
-  horizontalClamp: 15
 --- !u!1 &6202186160486810092
 GameObject:
   m_ObjectHideFlags: 0
@@ -552,6 +551,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 64
   collision: {fileID: 2916046406501991316}
+  orientationAnimator: {fileID: 2982298283658833489}
   _groundSpeed: 60
   _airSpeed: 6
   _jumpForce: 5
@@ -617,6 +617,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5567704814126278728}
+  - component: {fileID: 2982298283658833489}
   m_Layer: 3
   m_Name: Orientation
   m_TagString: Untagged
@@ -644,6 +645,28 @@ Transform:
   - {fileID: 1875896232990815028}
   m_Father: {fileID: 1634934622893517213}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &2982298283658833489
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8362820426947322467}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 781abe7ce940f0d48be4f53db08fb07e, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1001 &9007997696092631391
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Entities/Player/Player.prefab
+++ b/Assets/Prefabs/Entities/Player/Player.prefab
@@ -561,7 +561,7 @@ MonoBehaviour:
   _drag: 5
   _crouchDrag: 13
   _slideDrag: 0.4
-  _minSpeedToSlide: 8
+  _minSpeedToSlide: 3.5
   _minSpeedToWallRun: 8
 --- !u!114 &5965988180505858191
 MonoBehaviour:

--- a/Assets/Prefabs/Entities/Player/Player.prefab
+++ b/Assets/Prefabs/Entities/Player/Player.prefab
@@ -319,6 +319,7 @@ MonoBehaviour:
   orientation: {fileID: 5567704814126278728}
   mouseSensitivity: 300
   verticalClamp: 90
+  horizontalClamp: 15
 --- !u!1 &6202186160486810092
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PrototypeMap.unity
+++ b/Assets/Scenes/PrototypeMap.unity
@@ -41034,11 +41034,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1634934622893517213, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.86
+      value: 1.78
       objectReference: {fileID: 0}
     - target: {fileID: 1634934622893517213, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -9.59
+      value: -11.34
       objectReference: {fileID: 0}
     - target: {fileID: 1634934622893517213, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Scenes/PrototypeMap.unity
+++ b/Assets/Scenes/PrototypeMap.unity
@@ -2683,6 +2683,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1751862528}
+  - {fileID: 462580546}
   - {fileID: 262671073}
   - {fileID: 943080118}
   - {fileID: 582176276}
@@ -7507,6 +7508,142 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1022766245}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &462580545
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 462580546}
+  - component: {fileID: 462580548}
+  - component: {fileID: 462580547}
+  m_Layer: 5
+  m_Name: YRotation Tracker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &462580546
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462580545}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 128262756}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -610, y: -54.80005}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &462580547
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462580545}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 72
+  m_fontSizeBase: 72
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -490.0263, w: -35.214172}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &462580548
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 462580545}
+  m_CullTransparentMesh: 1
 --- !u!1 &464163718
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PrototypeMap.unity
+++ b/Assets/Scenes/PrototypeMap.unity
@@ -40937,7 +40937,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2211647097206558750, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: horizontalClamp
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2916046406501991316, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_ExcludeLayers.m_Bits

--- a/Assets/Scenes/PrototypeMap.unity
+++ b/Assets/Scenes/PrototypeMap.unity
@@ -40935,6 +40935,10 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2211647097206558750, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
+      propertyPath: horizontalClamp
+      value: 180
+      objectReference: {fileID: 0}
     - target: {fileID: 2916046406501991316, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_ExcludeLayers.m_Bits
       value: 640
@@ -40950,6 +40954,18 @@ PrefabInstance:
     - target: {fileID: 5252524867374529993, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: groundSpeed
       value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 5567704814126278728, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5567704814126278728, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5567704814126278728, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8142240636484815424, guid: 05972ec44309dfd46ba20df3bddb773b, type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/Player/PlayerCamera.cs
+++ b/Assets/Scripts/Player/PlayerCamera.cs
@@ -8,7 +8,8 @@ public class PlayerCamera : MonoBehaviour
     [Header("Settings")]
     [SerializeField] float mouseSensitivity = 100f;
     [SerializeField] float verticalClamp = 90f;
-    [SerializeField] float horizontalClamp = 180f;
+    float maxHorizontalClamp = 0f;
+    float minHorizontalClamp = 0f;
     private float xRotation = 0f;
     private float yRotation = 0f;
 
@@ -28,8 +29,9 @@ public class PlayerCamera : MonoBehaviour
         xRotation = Mathf.Clamp(xRotation, -verticalClamp, verticalClamp);
 
         yRotation += mouseX;
-        float positiveAngle = yRotation <= -90f ? yRotation + 360f : yRotation % 360f;
-        yRotation = horizontalClamp == 0 ? positiveAngle : Mathf.Clamp(positiveAngle, -horizontalClamp, horizontalClamp);
+        yRotation = (maxHorizontalClamp == minHorizontalClamp) 
+            ? yRotation % 360f 
+            : Mathf.Clamp(yRotation, minHorizontalClamp, maxHorizontalClamp) % 360f;
         
         transform.localRotation = Quaternion.Euler(xRotation, 0f, 0f);
         orientation.localRotation = Quaternion.Euler(0f, yRotation, 0f);
@@ -37,14 +39,20 @@ public class PlayerCamera : MonoBehaviour
         // Debug.Log("Rotation Y: " + yRotation);
     }
 
-    public void HorizontalClamp(float clamp)
+    public void SetHorizontalClamp(float min, float max)
     {
-        horizontalClamp = clamp % 360f;
+        minHorizontalClamp = min % 360f;
+        maxHorizontalClamp = max % 360f;
     }
-
     public void RemoveHorizontalClamp()
     {
-        horizontalClamp = 0;
+        minHorizontalClamp = 0;
+        maxHorizontalClamp = 0;
+    }
+
+    public float GetYRotation()
+    {
+        return yRotation;
     }
 
     public void SetYRotation(float yRotation)

--- a/Assets/Scripts/Player/PlayerCamera.cs
+++ b/Assets/Scripts/Player/PlayerCamera.cs
@@ -8,8 +8,9 @@ public class PlayerCamera : MonoBehaviour
     [Header("Settings")]
     [SerializeField] float mouseSensitivity = 100f;
     [SerializeField] float verticalClamp = 90f;
-
+    [SerializeField] float horizontalClamp = 180f;
     private float xRotation = 0f;
+    private float yRotation = 0f;
 
     void Start()
     {
@@ -26,7 +27,28 @@ public class PlayerCamera : MonoBehaviour
         xRotation -= mouseY;
         xRotation = Mathf.Clamp(xRotation, -verticalClamp, verticalClamp);
 
+        yRotation += mouseX;
+        float positiveAngle = yRotation <= -90f ? yRotation + 360f : yRotation % 360f;
+        yRotation = horizontalClamp == 0 ? positiveAngle : Mathf.Clamp(positiveAngle, -horizontalClamp, horizontalClamp);
+        
         transform.localRotation = Quaternion.Euler(xRotation, 0f, 0f);
-        orientation.Rotate(Vector3.up * mouseX);
+        orientation.localRotation = Quaternion.Euler(0f, yRotation, 0f);
+
+        Debug.Log("Rotation Y: " + yRotation);
+    }
+
+    public void HorizontalClamp(float clamp)
+    {
+        horizontalClamp = clamp % 360f;
+    }
+
+    public void RemoveHorizontalClamp()
+    {
+        horizontalClamp = 0;
+    }
+
+    public void SetYRotation(float yRotation)
+    {
+        this.yRotation = yRotation;
     }
 }

--- a/Assets/Scripts/Player/PlayerCamera.cs
+++ b/Assets/Scripts/Player/PlayerCamera.cs
@@ -34,7 +34,7 @@ public class PlayerCamera : MonoBehaviour
         transform.localRotation = Quaternion.Euler(xRotation, 0f, 0f);
         orientation.localRotation = Quaternion.Euler(0f, yRotation, 0f);
 
-        Debug.Log("Rotation Y: " + yRotation);
+        // Debug.Log("Rotation Y: " + yRotation);
     }
 
     public void HorizontalClamp(float clamp)

--- a/Assets/Scripts/Player/PlayerDebugging.cs
+++ b/Assets/Scripts/Player/PlayerDebugging.cs
@@ -6,6 +6,7 @@ public class PlayerDebugging : MonoBehaviour
     [Header("Settings")]
     [SerializeField] bool logLinearVelocity;
     TextMeshProUGUI speedTracker;
+    TextMeshProUGUI yRotationTracker;
     TextMeshProUGUI stateTracker;
     Rigidbody rb;
 
@@ -15,6 +16,7 @@ public class PlayerDebugging : MonoBehaviour
     {
         rb = GetComponent<Rigidbody>();
         speedTracker = GameObject.Find("Speed Tracker").GetComponent<TextMeshProUGUI>();
+        yRotationTracker = GameObject.Find("YRotation Tracker").GetComponent<TextMeshProUGUI>();
         stateTracker = GameObject.Find("State Tracker").GetComponent<TextMeshProUGUI>();
         playerStateMachine = GetComponent<PlayerStateMachine>();
     }
@@ -22,7 +24,7 @@ public class PlayerDebugging : MonoBehaviour
     void Update()
     {
         speedTracker.text = rb.linearVelocity.magnitude.ToString();
-        
+        yRotationTracker.text = playerStateMachine.PlayerCamera.GetYRotation().ToString();
         if (logLinearVelocity )
         {
             Debug.Log(rb.linearVelocity.magnitude);

--- a/Assets/Scripts/Player/PlayerDebugging.cs
+++ b/Assets/Scripts/Player/PlayerDebugging.cs
@@ -29,7 +29,7 @@ public class PlayerDebugging : MonoBehaviour
         }
 
         stateTracker.text = GetStateHistory();
-        Debug.Log(GetStateHistory());
+        // Debug.Log(GetStateHistory());
     }
 
     string GetStateHistory()

--- a/Assets/Scripts/Player/PlayerWallRun.cs
+++ b/Assets/Scripts/Player/PlayerWallRun.cs
@@ -62,8 +62,8 @@ public class PlayerWallRun : MonoBehaviour
         RaycastHit rightHit = WallRayCast(1);
         
         Vector3 wallNormal = leftHit.collider ? leftHit.normal : rightHit.normal;
-        
-        rb.AddForce(wallNormal * AWAy_FORCE, ForceMode.Impulse);
+        Vector3 perpendicularDirection = new Vector3(wallNormal.x, 0, -wallNormal.z).normalized;
+        rb.AddForce(perpendicularDirection * AWAy_FORCE, ForceMode.Impulse);
         rb.AddForce(Vector3.up * UP_FORCE, ForceMode.Impulse);
         rb.AddForce(direction * FORWARD_FORCE, ForceMode.Impulse);
     }

--- a/Assets/Scripts/Player/StateMachine/PlayerAirCrouchState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerAirCrouchState.cs
@@ -21,12 +21,14 @@ public class PlayerAirCrouchState : PlayerBaseState
     public override void FixedUpdateState(){}
     public override void ExitState()
     {
-        _context.StandUp();
+        // _context.StandUp();
     }
     public override void CheckSwitchStates()
     {
         if (!_context.IsCrouchPressed)
         {
+            _context.OrientationAnimator.SetTrigger("AirStandUp");
+            _context.OrientationAnimator.SetBool("AirCrouched", false);
             SwitchState(_factory.Freefall());
         }
     }
@@ -34,22 +36,24 @@ public class PlayerAirCrouchState : PlayerBaseState
 
     void Crouch()
     {
-        CapsuleCollider collision = _context.CollisionCapsule;
+        _context.OrientationAnimator.SetTrigger("AirCrouch");
+        _context.OrientationAnimator.SetBool("AirCrouched", true);
+        // CapsuleCollider collision = _context.CollisionCapsule;
 
-        collision.height = _context.CROUCH_COLLISION_HEIGHT;
-        Transform groundCheck = _context.GroundCollision;
-        groundCheck.localPosition = new Vector3(
-            groundCheck.localPosition.x, 
-            AIR_CROUCH_GROUNDCHECK_Y, 
-            groundCheck.localPosition.z
-        );
+        // collision.height = _context.CROUCH_COLLISION_HEIGHT;
+        // Transform groundCheck = _context.GroundCollision;
+        // groundCheck.localPosition = new Vector3(
+        //     groundCheck.localPosition.x, 
+        //     AIR_CROUCH_GROUNDCHECK_Y, 
+        //     groundCheck.localPosition.z
+        // );
 
-        _context.CameraTransform.localPosition = _context.InitCameraPos;
+        // _context.CameraTransform.localPosition = _context.InitCameraPos;
 
-        collision.center = new Vector3(
-            collision.center.x, 
-            _context.CROUCH_COLLISION_CENTER_Y, 
-            collision.center.z
-        );
+        // collision.center = new Vector3(
+        //     collision.center.x, 
+        //     _context.CROUCH_COLLISION_CENTER_Y, 
+        //     collision.center.z
+        // );
     }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerAirCrouchState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerAirCrouchState.cs
@@ -21,13 +21,12 @@ public class PlayerAirCrouchState : PlayerBaseState
     public override void FixedUpdateState(){}
     public override void ExitState()
     {
-        // _context.StandUp();
     }
     public override void CheckSwitchStates()
     {
         if (!_context.IsCrouchPressed)
         {
-            _context.OrientationAnimator.SetTrigger("AirStandUp");
+            _context.OrientationAnimator.Play("AirStandUp");
             _context.OrientationAnimator.SetBool("AirCrouched", false);
             SwitchState(_factory.Freefall());
         }
@@ -36,24 +35,8 @@ public class PlayerAirCrouchState : PlayerBaseState
 
     void Crouch()
     {
-        _context.OrientationAnimator.SetTrigger("AirCrouch");
-        _context.OrientationAnimator.SetBool("AirCrouched", true);
-        // CapsuleCollider collision = _context.CollisionCapsule;
-
-        // collision.height = _context.CROUCH_COLLISION_HEIGHT;
-        // Transform groundCheck = _context.GroundCollision;
-        // groundCheck.localPosition = new Vector3(
-        //     groundCheck.localPosition.x, 
-        //     AIR_CROUCH_GROUNDCHECK_Y, 
-        //     groundCheck.localPosition.z
-        // );
-
-        // _context.CameraTransform.localPosition = _context.InitCameraPos;
-
-        // collision.center = new Vector3(
-        //     collision.center.x, 
-        //     _context.CROUCH_COLLISION_CENTER_Y, 
-        //     collision.center.z
-        // );
+        Animator animator = _context.OrientationAnimator;
+        animator.Play("AirCrouch");
+        animator.SetBool("AirCrouched", true);
     }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerAirCrouchState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerAirCrouchState.cs
@@ -1,42 +1,29 @@
-using UnityEngine;
-
+/**
+* If you're surprised by the sheer amount of nothing happening
+* in this state, it's cause the actual crouching is handled by
+* the animator.
+*/
 public class PlayerAirCrouchState : PlayerBaseState
 {
-    const float AIR_CROUCH_GROUNDCHECK_Y = -0.248f;
-
     public PlayerAirCrouchState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
         name = "AirCrouch";
     }
 
-    public override void EnterState()
-    {
-        Crouch();
-    }
+    public override void EnterState(){}
     public override void UpdateState()
     {
         CheckSwitchStates();
     }
     public override void FixedUpdateState(){}
-    public override void ExitState()
-    {
-    }
+    public override void ExitState(){}
     public override void CheckSwitchStates()
     {
         if (!_context.IsCrouchPressed)
         {
-            _context.OrientationAnimator.Play("AirStandUp");
-            _context.OrientationAnimator.SetBool("AirCrouched", false);
             SwitchState(_factory.Freefall());
         }
     }
     public override void InitializeSubState(){}
-
-    void Crouch()
-    {
-        Animator animator = _context.OrientationAnimator;
-        animator.Play("AirCrouch");
-        animator.SetBool("AirCrouched", true);
-    }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerAirCrouchState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerAirCrouchState.cs
@@ -7,7 +7,7 @@ public class PlayerAirCrouchState : PlayerBaseState
     public PlayerAirCrouchState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
-        StateName = "AirCrouch";
+        name = "AirCrouch";
     }
 
     public override void EnterState()

--- a/Assets/Scripts/Player/StateMachine/PlayerAirMoveState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerAirMoveState.cs
@@ -5,7 +5,7 @@ public class PlayerAirMoveState : PlayerBaseState
     public PlayerAirMoveState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
-        StateName = "AirMove";
+        name = "AirMove";
         InitializeSubState();
     }
 

--- a/Assets/Scripts/Player/StateMachine/PlayerAirMoveState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerAirMoveState.cs
@@ -14,7 +14,10 @@ public class PlayerAirMoveState : PlayerBaseState
     {
         CheckSwitchStates();
     }
-    public override void FixedUpdateState(){}
+    public override void FixedUpdateState()
+    {
+        Move();
+    }
     public override void ExitState(){}
     public override void CheckSwitchStates()
     {
@@ -23,6 +26,12 @@ public class PlayerAirMoveState : PlayerBaseState
             float horizontalVelocity = Vector3.Scale(_context.PlayerRigidBody.linearVelocity, new Vector3(1,0,1)).magnitude;
             if(horizontalVelocity >= _context.MinSpeedToWallRun && _context.IsTouchingWall() == _context.HorizontalInput)
             {
+                GameObject wall = _context.WallRayCast((int)_context.HorizontalInput).collider.gameObject;
+                PlayerAirborneState superState = (PlayerAirborneState) currentSuperState;
+                
+                if (wall == superState.LastWallRunSurface) return;
+                
+                superState.LastWallRunSurface = wall;
                 currentSubState.ExitState();
                 SwitchState(_factory.WallRun());
             } 
@@ -35,5 +44,16 @@ public class PlayerAirMoveState : PlayerBaseState
         else
             SetSubState(_factory.Freefall());
         currentSubState.EnterState();
+    }
+    void Move()
+    {
+        float horizontal = _context.HorizontalInput;
+        float vertical = _context.VerticalInput;
+        float multiplier = _context.AirMultiplier;
+        Transform orientation = _context.PlayerOrientation;
+        Vector3 directionVector = orientation.forward * vertical + orientation.right * horizontal;
+        Rigidbody rb = _context.PlayerRigidBody;
+
+        rb.AddForce(directionVector.normalized * _context.AirSpeed * multiplier);
     }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerAirborneState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerAirborneState.cs
@@ -2,11 +2,16 @@ using UnityEngine;
 
 public class PlayerAirborneState : PlayerBaseState
 {
+
+    GameObject _lastWallRunSurface; // god i fucking hate the name of this variable.
+    public GameObject LastWallRunSurface { get { return _lastWallRunSurface; } set { _lastWallRunSurface = value; } }
+
     public PlayerAirborneState(PlayerStateMachine context, PlayerStateFactory factory)
     : base(context, factory)
     {
         isRootState = true;
         StateName = "Airborne";
+        _lastWallRunSurface = null;
         InitializeSubState();
     }
 
@@ -22,7 +27,6 @@ public class PlayerAirborneState : PlayerBaseState
     {
         _context.PlayerRigidBody.linearDamping = 0;
         LimitSpeed();
-        Move();
     }
     public override void ExitState()
     {
@@ -51,15 +55,5 @@ public class PlayerAirborneState : PlayerBaseState
             rb.linearVelocity = new Vector3(xzVelocity.x, rb.linearVelocity.y, xzVelocity.z);
         }
     }
-    void Move()
-    {
-        float horizontal = _context.HorizontalInput;
-        float vertical = _context.VerticalInput;
-        float multiplier = _context.AirMultiplier;
-        Transform orientation = _context.PlayerOrientation;
-        Vector3 directionVector = orientation.forward * vertical + orientation.right * horizontal;
-        Rigidbody rb = _context.PlayerRigidBody;
 
-        rb.AddForce(directionVector.normalized * _context.AirSpeed * multiplier);
-    }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerAirborneState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerAirborneState.cs
@@ -10,7 +10,7 @@ public class PlayerAirborneState : PlayerBaseState
     : base(context, factory)
     {
         isRootState = true;
-        StateName = "Airborne";
+        name = "Airborne";
         _lastWallRunSurface = null;
         InitializeSubState();
     }

--- a/Assets/Scripts/Player/StateMachine/PlayerAirborneState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerAirborneState.cs
@@ -18,6 +18,7 @@ public class PlayerAirborneState : PlayerBaseState
     public override void EnterState()
     {
         _context.CurrentDrag = 0;
+        _context.OrientationAnimator.SetBool("Grounded", false);
     }
     public override void UpdateState()
     {

--- a/Assets/Scripts/Player/StateMachine/PlayerBaseState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerBaseState.cs
@@ -9,12 +9,11 @@ public abstract class PlayerBaseState : BaseState
 {
     protected PlayerStateMachine _context;
     protected PlayerStateFactory _factory;
-    string _stateName;
-    public string StateName { get { return _stateName; } set { _stateName = value; } }
+    
     public PlayerBaseState(PlayerStateMachine context, PlayerStateFactory factory) : base(context, factory)
     {
         _context = context;
         _factory = factory;
-        _stateName = "";
+        name = "";
     }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
@@ -27,11 +27,11 @@ public class PlayerCrouchState : PlayerBaseState
             if(_context.OrientationAnimator.GetBool("AirCrouched"))
             {
                 _context.OrientationAnimator.SetBool("AirCrouched", false);
-                _context.OrientationAnimator.SetTrigger("AirStandUp");   
+                _context.OrientationAnimator.Play("AirStandUp");   
             }
             else
             {
-                _context.OrientationAnimator.SetTrigger("GroundStandUp");   
+                _context.OrientationAnimator.Play("GroundStandUp");   
             }
             SwitchState(_factory.Run());
         }
@@ -40,38 +40,8 @@ public class PlayerCrouchState : PlayerBaseState
 
     void Crouch()
     {
-        if( _context.OrientationAnimator.GetBool("AirCrouched"))
+        if(_context.OrientationAnimator.GetBool("AirCrouched"))
             return;
-        _context.OrientationAnimator.SetTrigger("GroundCrouch");
-
-        // CapsuleCollider collision = _context.CollisionCapsule;
-        // if(collision.height == _context.CROUCH_COLLISION_HEIGHT) // If we're already crouched, skip
-        //     return;
-        
-        // collision.height = _context.CROUCH_COLLISION_HEIGHT;
-
-        // bool wasAirCrouching = collision.center.y > _context.InitCollisionPosY;
-        // if(wasAirCrouching) // If we were air crouching, don't adjust the groundCheck or collision capsule position
-        //     return;
-
-        // Transform groundCheck = _context.GroundCollision;
-        // groundCheck.localPosition = new Vector3(
-        //     groundCheck.localPosition.x, 
-        //     _context.InitGroundCheckY, 
-        //     groundCheck.localPosition.z
-        // );
-        // collision.center = new Vector3(
-        //     collision.center.x, 
-        //     -_context.CROUCH_COLLISION_CENTER_Y, 
-        //     collision.center.z
-        // );   
-
-        // Transform cameraTransform = _context.CameraTransform;
-        // Vector3 initCameraPos = _context.InitCameraPos;
-        // cameraTransform.localPosition = new Vector3(
-        //     initCameraPos.x, 
-        //     collision.center.y + CROUCH_CAMERA_Y_OFFSET, 
-        //     initCameraPos.z
-        // );
+        _context.OrientationAnimator.Play("GroundCrouch");
     }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
@@ -24,6 +24,15 @@ public class PlayerCrouchState : PlayerBaseState
     {
         if (!_context.IsCrouchPressed)
         {
+            if(_context.OrientationAnimator.GetBool("AirCrouched"))
+            {
+                _context.OrientationAnimator.SetBool("AirCrouched", false);
+                _context.OrientationAnimator.SetTrigger("AirStandUp");   
+            }
+            else
+            {
+                _context.OrientationAnimator.SetTrigger("GroundStandUp");   
+            }
             SwitchState(_factory.Run());
         }
     }
@@ -31,35 +40,38 @@ public class PlayerCrouchState : PlayerBaseState
 
     void Crouch()
     {
-        CapsuleCollider collision = _context.CollisionCapsule;
-        if(collision.height == _context.CROUCH_COLLISION_HEIGHT) // If we're already crouched, skip
+        if( _context.OrientationAnimator.GetBool("AirCrouched"))
             return;
+        _context.OrientationAnimator.SetTrigger("GroundCrouch");
+
+        // CapsuleCollider collision = _context.CollisionCapsule;
+        // if(collision.height == _context.CROUCH_COLLISION_HEIGHT) // If we're already crouched, skip
+        //     return;
         
-        collision.height = _context.CROUCH_COLLISION_HEIGHT;
+        // collision.height = _context.CROUCH_COLLISION_HEIGHT;
 
-        bool wasAirCrouching = collision.center.y > _context.InitCollisionPosY;
-        if(wasAirCrouching) // If we were air crouching, don't adjust the groundCheck or collision capsule position
-            return;
+        // bool wasAirCrouching = collision.center.y > _context.InitCollisionPosY;
+        // if(wasAirCrouching) // If we were air crouching, don't adjust the groundCheck or collision capsule position
+        //     return;
 
-        Transform groundCheck = _context.GroundCollision;
-        groundCheck.localPosition = new Vector3(
-            groundCheck.localPosition.x, 
-            _context.InitGroundCheckY, 
-            groundCheck.localPosition.z
-        );
+        // Transform groundCheck = _context.GroundCollision;
+        // groundCheck.localPosition = new Vector3(
+        //     groundCheck.localPosition.x, 
+        //     _context.InitGroundCheckY, 
+        //     groundCheck.localPosition.z
+        // );
+        // collision.center = new Vector3(
+        //     collision.center.x, 
+        //     -_context.CROUCH_COLLISION_CENTER_Y, 
+        //     collision.center.z
+        // );   
 
-        collision.center = new Vector3(
-            collision.center.x, 
-            -_context.CROUCH_COLLISION_CENTER_Y, 
-            collision.center.z
-        );   
-
-        Transform cameraTransform = _context.CameraTransform;
-        Vector3 initCameraPos = _context.InitCameraPos;
-        cameraTransform.localPosition = new Vector3(
-            initCameraPos.x, 
-            collision.center.y + CROUCH_CAMERA_Y_OFFSET, 
-            initCameraPos.z
-        );
+        // Transform cameraTransform = _context.CameraTransform;
+        // Vector3 initCameraPos = _context.InitCameraPos;
+        // cameraTransform.localPosition = new Vector3(
+        //     initCameraPos.x, 
+        //     collision.center.y + CROUCH_CAMERA_Y_OFFSET, 
+        //     initCameraPos.z
+        // );
     }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
@@ -1,47 +1,29 @@
-using UnityEngine;
-
+/**
+* If you're surprised by the sheer amount of nothing happening
+* in this state, it's cause the actual crouching is handled by
+* the animator.
+*/
 public class PlayerCrouchState : PlayerBaseState
 {
-    const float CROUCH_CAMERA_Y_OFFSET = 0.335f; 
-
     public PlayerCrouchState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory){}
     public override void EnterState()
     {
         name = "Crouch";
         _context.CurrentDrag = _context.CrouchDrag;
-        Crouch();
     }
     public override void UpdateState()
     {
         CheckSwitchStates();
     }
     public override void FixedUpdateState(){}
-    public override void ExitState()
-    {
-    }
+    public override void ExitState(){}
     public override void CheckSwitchStates()
     {
         if (!_context.IsCrouchPressed)
         {
-            if(_context.OrientationAnimator.GetBool("AirCrouched"))
-            {
-                _context.OrientationAnimator.SetBool("AirCrouched", false);
-                _context.OrientationAnimator.Play("AirStandUp");   
-            }
-            else
-            {
-                _context.OrientationAnimator.Play("GroundStandUp");   
-            }
             SwitchState(_factory.Run());
         }
     }
     public override void InitializeSubState(){}
-
-    void Crouch()
-    {
-        if(_context.OrientationAnimator.GetBool("AirCrouched"))
-            return;
-        _context.OrientationAnimator.Play("GroundCrouch");
-    }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class PlayerCrouchState : PlayerBaseState
 {
-    const float CROUCH_CAMERA_Y_OFFSET = 0.3f; 
+    const float CROUCH_CAMERA_Y_OFFSET = 0.335f; 
 
     public PlayerCrouchState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory){}
@@ -58,7 +58,7 @@ public class PlayerCrouchState : PlayerBaseState
         Vector3 initCameraPos = _context.InitCameraPos;
         cameraTransform.localPosition = new Vector3(
             initCameraPos.x, 
-            collision.center.y - CROUCH_CAMERA_Y_OFFSET, 
+            collision.center.y + CROUCH_CAMERA_Y_OFFSET, 
             initCameraPos.z
         );
     }

--- a/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerCrouchState.cs
@@ -8,7 +8,7 @@ public class PlayerCrouchState : PlayerBaseState
     :base(context, factory){}
     public override void EnterState()
     {
-        StateName = "Crouch";
+        name = "Crouch";
         _context.CurrentDrag = _context.CrouchDrag;
         Crouch();
     }

--- a/Assets/Scripts/Player/StateMachine/PlayerFreefallState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerFreefallState.cs
@@ -7,7 +7,7 @@ public class PlayerFreefallState : PlayerBaseState
     public PlayerFreefallState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
-        StateName = "Freefall";
+        name = "Freefall";
         _crouchTimer = -1.0f;
     }
 

--- a/Assets/Scripts/Player/StateMachine/PlayerFreefallState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerFreefallState.cs
@@ -3,22 +3,15 @@ using UnityEngine;
 
 public class PlayerFreefallState : PlayerBaseState
 {
-    float _crouchTimer;
     public PlayerFreefallState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
         name = "Freefall";
-        _crouchTimer = -1.0f;
     }
 
     public override void EnterState(){}
     public override void UpdateState()
     {
-        if(_crouchTimer >= 0.0f)
-        {
-            _crouchTimer -= Time.deltaTime;
-            Debug.Log(_crouchTimer);   
-        }
         CheckSwitchStates();
     }
     public override void FixedUpdateState(){}
@@ -30,11 +23,8 @@ public class PlayerFreefallState : PlayerBaseState
     public override void InitializeSubState(){}
     void Crouch()
     {
-        if (_context.ReleasedCrouch)
-        {
-            _crouchTimer = _context.CROUCH_COOLDOWN;
-        }
-        if (_context.PressedCrouch && _crouchTimer <= 0.0f)
+
+        if (_context.PressedCrouch)
         {
             SwitchState(_factory.AirCrouch());
         }

--- a/Assets/Scripts/Player/StateMachine/PlayerFreefallState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerFreefallState.cs
@@ -18,15 +18,10 @@ public class PlayerFreefallState : PlayerBaseState
     public override void ExitState(){}
     public override void CheckSwitchStates()
     {
-        Crouch();
-    }
-    public override void InitializeSubState(){}
-    void Crouch()
-    {
-
-        if (_context.PressedCrouch)
+        if (_context.PressedCrouch && _context.OrientationAnimator.GetCurrentAnimatorStateInfo(0).IsName("Idle"))
         {
             SwitchState(_factory.AirCrouch());
         }
     }
+    public override void InitializeSubState(){}
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerGroundedState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerGroundedState.cs
@@ -11,7 +11,10 @@ public class PlayerGroundedState : PlayerBaseState
         InitializeSubState();
     }
 
-    public override void EnterState(){}
+    public override void EnterState()
+    {
+        _context.OrientationAnimator.SetBool("Grounded", true);
+    }
     public override void UpdateState()
     {
         CheckSwitchStates();
@@ -21,7 +24,11 @@ public class PlayerGroundedState : PlayerBaseState
         _context.PlayerRigidBody.linearDamping = _context.CurrentDrag;
         LimitSpeed();
     }
-    public override void ExitState(){}
+    public override void ExitState()
+    {
+        _context.OrientationAnimator.SetBool("Sliding", false);
+        currentSubState?.ExitState();
+    }
     public override void CheckSwitchStates()
     {
         if (!_context.Grounded)

--- a/Assets/Scripts/Player/StateMachine/PlayerGroundedState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerGroundedState.cs
@@ -6,7 +6,7 @@ public class PlayerGroundedState : PlayerBaseState
     public PlayerGroundedState(PlayerStateMachine context, PlayerStateFactory factory)
     : base(context, factory)
     {
-        StateName = "Grounded";
+        name = "Grounded";
         isRootState = true;
         InitializeSubState();
     }

--- a/Assets/Scripts/Player/StateMachine/PlayerMoveState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerMoveState.cs
@@ -21,7 +21,13 @@ public class PlayerMoveState : PlayerBaseState
     public override void ExitState(){}
     public override void CheckSwitchStates()
     {   
-        if (_context.IsCrouchPressed && _context.VerticalInput == 1.0f)
+        float horizontalVelocity = Vector3.Scale(_context.PlayerRigidBody.linearVelocity, new Vector3(1,0,1)).magnitude;
+
+        if (
+            _context.IsCrouchPressed 
+            && _context.VerticalInput == 1.0f
+            && horizontalVelocity >= _context.MinSpeedToSlide
+        )
         {
             SwitchState(_factory.Slide());
         }
@@ -41,7 +47,12 @@ public class PlayerMoveState : PlayerBaseState
         Transform orientation = _context.PlayerOrientation;
         Vector3 directionVector = orientation.forward * vertical + orientation.right * horizontal;
         Rigidbody rb = _context.PlayerRigidBody;
-
-        rb.AddForce(directionVector.normalized * _context.GroundSpeed);
+        
+        float nonForwardMultiplier = 0.65f;
+        rb.AddForce(
+            directionVector.normalized 
+            * _context.GroundSpeed 
+            * ((vertical < 0 && horizontal == 0) ? nonForwardMultiplier : 1.0f)
+        );
     }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerMoveState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerMoveState.cs
@@ -23,15 +23,7 @@ public class PlayerMoveState : PlayerBaseState
     {   
         if (_context.IsCrouchPressed && _context.VerticalInput == 1.0f)
         {
-            float horizontalVelocity = Vector3.Scale(
-                _context.PlayerRigidBody.linearVelocity, 
-                new Vector3(1,0,1)
-            ).magnitude; 
-            
-            if(horizontalVelocity >= _context.MinSpeedToSlide)
-            {
-                SwitchState(_factory.Slide());
-            }
+            SwitchState(_factory.Slide());
         }
     }
     public override void InitializeSubState()

--- a/Assets/Scripts/Player/StateMachine/PlayerMoveState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerMoveState.cs
@@ -9,7 +9,9 @@ public class PlayerMoveState : PlayerBaseState
         InitializeSubState();
     }
     
-    public override void EnterState(){}
+    public override void EnterState()
+    {
+    }
     public override void UpdateState()
     {
         CheckSwitchStates();

--- a/Assets/Scripts/Player/StateMachine/PlayerMoveState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerMoveState.cs
@@ -5,7 +5,7 @@ public class PlayerMoveState : PlayerBaseState
     public PlayerMoveState(PlayerStateMachine context, PlayerStateFactory factory)
     : base(context, factory)
     {
-        StateName = "Move";
+        name = "Move";
         InitializeSubState();
     }
     

--- a/Assets/Scripts/Player/StateMachine/PlayerRunState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerRunState.cs
@@ -27,7 +27,7 @@ public class PlayerRunState : PlayerBaseState
                 new Vector3(1,0,1)
             ).magnitude; 
             
-            if(horizontalSpeed < _context.MinSpeedToSlide && _context.OrientationAnimator.GetCurrentAnimatorStateInfo(0).IsName("Idle"))
+            if(horizontalSpeed < _context.MinSpeedToSlide)
             {
                 SwitchState(_factory.Crouch());
             }

--- a/Assets/Scripts/Player/StateMachine/PlayerRunState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerRunState.cs
@@ -6,7 +6,7 @@ public class PlayerRunState : PlayerBaseState
     public PlayerRunState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
-        StateName = "Run";
+        name = "Run";
     }
     public override void EnterState()
     {

--- a/Assets/Scripts/Player/StateMachine/PlayerRunState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerRunState.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 
 public class PlayerRunState : PlayerBaseState
 {
-    float _crouchTimer;
     public PlayerRunState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
@@ -11,7 +10,6 @@ public class PlayerRunState : PlayerBaseState
     public override void EnterState()
     {
         _context.CurrentDrag = _context.Drag;
-        _context.StandUp();
     }
     public override void UpdateState()
     {
@@ -29,7 +27,7 @@ public class PlayerRunState : PlayerBaseState
                 new Vector3(1,0,1)
             ).magnitude; 
             
-            if(horizontalSpeed < _context.MinSpeedToSlide && _crouchTimer <= 0)
+            if(horizontalSpeed < _context.MinSpeedToSlide)
             {
                 SwitchState(_factory.Crouch());
             }

--- a/Assets/Scripts/Player/StateMachine/PlayerRunState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerRunState.cs
@@ -27,7 +27,7 @@ public class PlayerRunState : PlayerBaseState
                 new Vector3(1,0,1)
             ).magnitude; 
             
-            if(horizontalSpeed < _context.MinSpeedToSlide)
+            if(horizontalSpeed < _context.MinSpeedToSlide && _context.OrientationAnimator.GetCurrentAnimatorStateInfo(0).IsName("Idle"))
             {
                 SwitchState(_factory.Crouch());
             }

--- a/Assets/Scripts/Player/StateMachine/PlayerSlideState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerSlideState.cs
@@ -1,9 +1,11 @@
 using UnityEngine;
-
+/**
+* If you're surprised by the sheer amount of nothing happening
+* in this state, it's cause the actual sliding is handled by
+* the animator.
+*/
 public class PlayerSlideState : PlayerBaseState
 {
-    const float SLIDE_CAMERA_OFFSET = 0.9f;
-    const float SLIDE_COLLISION_CENTER_Y = 0.5f;
     const float JUMP_COOLDOWN_AFTER_SLIDE = .9f;
     
     float _jumpCooldown = 0;
@@ -14,11 +16,17 @@ public class PlayerSlideState : PlayerBaseState
         name = "Slide";
         _jumpCooldown = JUMP_COOLDOWN_AFTER_SLIDE;
     }
+    ~PlayerSlideState()
+    {
+        ExitState();
+    }
     public override void EnterState()
     {
+        if(!_context.Grounded) return;
         _context.CurrentDrag = _context.SlideDrag;
-        LieDown();
+        _context.OrientationAnimator.SetBool("Sliding", true);
     }
+
     public override void UpdateState()
     {
         if (_jumpCooldown <= 0)
@@ -29,42 +37,17 @@ public class PlayerSlideState : PlayerBaseState
         CheckSwitchStates();
     }
     public override void FixedUpdateState(){}
-    public override void ExitState(){}
+    public override void ExitState()
+    {
+        _context.OrientationAnimator.SetBool("Sliding", false);
+    }
     public override void CheckSwitchStates()
     {
         float minSpeedToStopSlide = 3.8f;
-        if (
-            !_context.IsCrouchPressed 
-            || _context.PlayerRigidBody.linearVelocity.magnitude <= minSpeedToStopSlide
-        )
+        if (!_context.IsCrouchPressed || _context.PlayerRigidBody.linearVelocity.magnitude <= minSpeedToStopSlide)
         {
             SwitchState(_factory.Move());
         }
     }
     public override void InitializeSubState(){}
-
-    void LieDown()
-    {
-        CapsuleCollider collision = _context.CollisionCapsule;
-        if(collision.height < _context.InitCollisionHeight)
-        {
-            collision.height = _context.SLIDE_COLLISION_HEIGHT;
-            return;
-        }
-
-        collision.height = _context.SLIDE_COLLISION_HEIGHT;
-        collision.center = new Vector3(
-            collision.center.x, 
-            -SLIDE_COLLISION_CENTER_Y, 
-            collision.center.z
-        );
-        
-        Transform cameraTransform = _context.CameraTransform;
-        Vector3 initCameraPos = _context.InitCameraPos;
-        cameraTransform.localPosition = new Vector3(
-            initCameraPos.x, 
-            initCameraPos.y - SLIDE_CAMERA_OFFSET, 
-            initCameraPos.z
-        );
-    }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerSlideState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerSlideState.cs
@@ -11,7 +11,7 @@ public class PlayerSlideState : PlayerBaseState
     public PlayerSlideState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
-        StateName = "Slide";
+        name = "Slide";
         _jumpCooldown = JUMP_COOLDOWN_AFTER_SLIDE;
     }
     public override void EnterState()

--- a/Assets/Scripts/Player/StateMachine/PlayerStateMachine.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerStateMachine.cs
@@ -37,6 +37,7 @@ public class PlayerStateMachine : BaseStateMachine
     Rigidbody rb;
     Transform orientation;
     PlayerAim playerAim;
+    PlayerCamera playerCamera;
 
     PlayerStateFactory _states;
 
@@ -45,6 +46,7 @@ public class PlayerStateMachine : BaseStateMachine
     public Rigidbody PlayerRigidBody { get{ return rb; } }
     public Transform PlayerOrientation { get{ return orientation; } }
     public Transform WallCheckOrigin { get { return wallCheckOrigin; } }
+    public PlayerCamera PlayerCamera { get { return playerCamera; } }
 
     public bool Grounded { get{ return Physics.CheckSphere(groundCheck.position, groundCheck.GetComponent<SphereCollider>().radius, groundLayer); }}
     public bool PressedJump { get { return Input.GetKeyDown(KeyCode.Space); } } 
@@ -94,6 +96,7 @@ public class PlayerStateMachine : BaseStateMachine
         playerAim = GetComponent<PlayerAim>();
         rb = GetComponent<Rigidbody>();
         orientation = transform.Find("Orientation");
+        playerCamera = GetComponentInChildren<PlayerCamera>();
         
         _gameStateManager = FindFirstObjectByType<GameStateManager>();
 

--- a/Assets/Scripts/Player/StateMachine/PlayerStateMachine.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerStateMachine.cs
@@ -128,6 +128,12 @@ public class PlayerStateMachine : BaseStateMachine
         if(WallRayCast(1).collider) return 1;
         return 0;
     }
+    public int IsTouchingWall(float distance)
+    {
+        if(WallRayCast(-1, distance).collider) return -1;
+        if(WallRayCast(1, distance).collider) return 1;
+        return 0;
+    }
     
     public RaycastHit WallRayCast(int dir)
     {
@@ -138,6 +144,18 @@ public class PlayerStateMachine : BaseStateMachine
             dir * PlayerOrientation.right,
             out RaycastHit hit,
             WALL_CHECK_DIST,
+            WallLayers
+        );    
+        
+        return hit;
+    }
+    public RaycastHit WallRayCast(int dir, float distance)
+    {
+        Physics.Raycast(
+            WallCheckOrigin.position,
+            dir * PlayerOrientation.right,
+            out RaycastHit hit,
+            distance,
             WallLayers
         );    
         

--- a/Assets/Scripts/Player/StateMachine/PlayerStateMachine.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerStateMachine.cs
@@ -113,6 +113,12 @@ public class PlayerStateMachine : BaseStateMachine
         Debug.Log(CurrentState);
     }
 
+    protected override void Update()
+    {
+        base.Update();
+        orientationAnimator.SetBool("CrouchPressed", IsCrouchPressed);
+    }
+
     public void Jump()
     {
         if (!Grounded) return;
@@ -161,19 +167,6 @@ public class PlayerStateMachine : BaseStateMachine
         );    
         
         return hit;
-    }
-    public void StandUp()
-    {
-        collision.center = new Vector3(collision.center.x, InitCollisionPosY, collision.center.z);
-        collision.height = InitCollisionHeight;
-
-        cameraTransform.localPosition = InitCameraPos;
-
-        groundCheck.localPosition = new Vector3(
-            groundCheck.localPosition.x, 
-            InitGroundCheckY, 
-            groundCheck.localPosition.z
-        );
     }
 
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerStateMachine.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerStateMachine.cs
@@ -13,6 +13,7 @@ public class PlayerStateMachine : BaseStateMachine
     [SerializeField] LayerMask wallLayers;
     [SerializeField] LayerMask groundLayer;
     [SerializeField] CapsuleCollider collision;
+    [SerializeField] Animator orientationAnimator;
 
     [Header ("Movement Settings")]
     [SerializeField] float _groundSpeed;
@@ -84,7 +85,7 @@ public class PlayerStateMachine : BaseStateMachine
     public Transform GroundCollision { get { return groundCheck; } } 
     public Transform CameraTransform { get { return cameraTransform; } }
     public Vector3 InitCameraPos { get { return _initCameraPos; } }
-
+    public Animator OrientationAnimator { get { return orientationAnimator; } }
     public LayerMask WallLayers { get { return wallLayers; } }
 
     public PlayerAim Aim { get { return playerAim; } }

--- a/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
@@ -9,7 +9,7 @@ public class PlayerWallRunState : PlayerBaseState
     public PlayerWallRunState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
-        StateName = "WallRun";
+        name = "WallRun";
         RaycastHit leftHit = _context.WallRayCast(-1);
         RaycastHit rightHit = _context.WallRayCast(1);
         wallNormal = leftHit.collider ? leftHit.normal : rightHit.normal;

--- a/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
@@ -3,15 +3,22 @@ using UnityEngine;
 public class PlayerWallRunState : PlayerBaseState
 {
     const float FORWARD_FORCE = 2.0f; 
-    public float AWAY_FORCE = 4f; 
+    public float AWAY_FORCE = 4f;
+    Vector3 wallNormal, adjacentNormal;
 
     public PlayerWallRunState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
         StateName = "WallRun";
+        RaycastHit leftHit = _context.WallRayCast(-1);
+        RaycastHit rightHit = _context.WallRayCast(1);
+        wallNormal = leftHit.collider ? leftHit.normal : rightHit.normal;
+        adjacentNormal = Vector3.Cross(wallNormal, Vector3.up).normalized;
     }
 
-    public override void EnterState(){}
+    public override void EnterState()
+    {
+    }
     public override void UpdateState()
     {
         CheckSwitchStates();
@@ -21,7 +28,10 @@ public class PlayerWallRunState : PlayerBaseState
     {
         WallRun();
     }
-    public override void ExitState(){}
+    public override void ExitState()
+    {
+        _context.PlayerCamera.RemoveHorizontalClamp();
+    }
     public override void CheckSwitchStates()
     {
         if(_context.IsTouchingWall() == 0)
@@ -32,16 +42,12 @@ public class PlayerWallRunState : PlayerBaseState
     public override void InitializeSubState(){}
     void WallRun()
     {
-        Debug.Log("RUNNING");
         _context.PlayerRigidBody.AddForce(Vector3.up * _context.UP_FORCE);
+        Quaternion rotation = Quaternion.LookRotation(adjacentNormal, Vector3.up);
+        _context.PlayerCamera.HorizontalClamp(rotation.eulerAngles.y + 30f);
     }
     void WallJump(Vector3 direction)
-    {
-        RaycastHit leftHit = _context.WallRayCast(-1);
-        RaycastHit rightHit = _context.WallRayCast(1);
-        
-        Vector3 wallNormal = leftHit.collider ? leftHit.normal : rightHit.normal;
-        
+    {   
         Rigidbody rb = _context.PlayerRigidBody;
         rb.AddForce(wallNormal * AWAY_FORCE, ForceMode.Impulse);
         rb.AddForce(Vector3.up * (_context.UP_FORCE / 1.2f), ForceMode.Impulse);

--- a/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
@@ -3,9 +3,9 @@ using UnityEngine;
 public class PlayerWallRunState : PlayerBaseState
 {
     const float FORWARD_FORCE = 2.0f; 
-    public float AWAY_FORCE = 4f;
+    const float MIN_VELOCITY_TO_KEEP_RUN = 4.0f;
+    public float AWAY_FORCE = 4.0f;
     Vector3 wallNormal, adjacentNormal;
-
     public PlayerWallRunState(PlayerStateMachine context, PlayerStateFactory factory)
     :base(context, factory)
     {
@@ -16,9 +16,8 @@ public class PlayerWallRunState : PlayerBaseState
         adjacentNormal = Vector3.Cross(wallNormal, Vector3.up).normalized;
     }
 
-    public override void EnterState()
-    {
-    }
+    public override void EnterState(){}
+
     public override void UpdateState()
     {
         CheckSwitchStates();
@@ -30,28 +29,39 @@ public class PlayerWallRunState : PlayerBaseState
     }
     public override void ExitState()
     {
-        _context.PlayerCamera.RemoveHorizontalClamp();
     }
     public override void CheckSwitchStates()
     {
-        if(_context.IsTouchingWall() == 0)
+        const float RAYCAST_REACH_TO_KEEP_RUN = 2.0f;
+        float horizontalVelocity = Vector3.Scale(_context.PlayerRigidBody.linearVelocity, new Vector3(1,0,1)).magnitude;
+        if(
+            _context.IsTouchingWall(RAYCAST_REACH_TO_KEEP_RUN) == 0 
+            || _context.IsCrouchPressed == true 
+            || horizontalVelocity < MIN_VELOCITY_TO_KEEP_RUN
+        )
         {
-           SwitchState(_factory.Freefall()); 
+           SwitchState(_factory.AirMove()); 
         }
     }
     public override void InitializeSubState(){}
     void WallRun()
     {
-        _context.PlayerRigidBody.AddForce(Vector3.up * _context.UP_FORCE);
-        Quaternion rotation = Quaternion.LookRotation(adjacentNormal, Vector3.up);
-        _context.PlayerCamera.HorizontalClamp(rotation.eulerAngles.y + 30f);
+        float vertical = _context.VerticalInput;
+        float multiplier = _context.AirMultiplier;
+        Transform orientation = _context.PlayerOrientation;
+        Vector3 directionVector = orientation.forward - wallNormal;
+        Rigidbody rb = _context.PlayerRigidBody;
+        rb.AddForce(directionVector.normalized * _context.AirSpeed * multiplier);
+        rb.AddForce(Vector3.up * _context.UP_FORCE);
     }
+
     void WallJump(Vector3 direction)
     {   
         Rigidbody rb = _context.PlayerRigidBody;
         rb.AddForce(wallNormal * AWAY_FORCE, ForceMode.Impulse);
         rb.AddForce(Vector3.up * (_context.UP_FORCE / 1.2f), ForceMode.Impulse);
         rb.AddForce(direction * FORWARD_FORCE, ForceMode.Impulse);
+        SwitchState(_factory.AirMove()); 
     }
     void Jump()
     {

--- a/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
@@ -14,6 +14,8 @@ public class PlayerWallRunState : PlayerBaseState
         RaycastHit rightHit = _context.WallRayCast(1);
         wallNormal = leftHit.collider ? leftHit.normal : rightHit.normal;
         adjacentNormal = Vector3.Cross(wallNormal, Vector3.up).normalized;
+
+        SetClamp();
     }
 
     public override void EnterState(){}
@@ -29,6 +31,7 @@ public class PlayerWallRunState : PlayerBaseState
     }
     public override void ExitState()
     {
+        _context.PlayerCamera.RemoveHorizontalClamp();
     }
     public override void CheckSwitchStates()
     {
@@ -46,7 +49,6 @@ public class PlayerWallRunState : PlayerBaseState
     public override void InitializeSubState(){}
     void WallRun()
     {
-        float vertical = _context.VerticalInput;
         float multiplier = _context.AirMultiplier;
         Transform orientation = _context.PlayerOrientation;
         Vector3 directionVector = orientation.forward - wallNormal;
@@ -67,5 +69,23 @@ public class PlayerWallRunState : PlayerBaseState
     {
         if(_context.PressedJump)
             WallJump(_context.Aim.cameraForward());
+    }
+
+    void SetClamp()
+    {
+        const float CLAMP_ANGLE = 73f;
+        Quaternion adjacentLookDir = Quaternion.LookRotation(adjacentNormal, Vector3.up);
+        float adjacentLookAngle = adjacentLookDir.eulerAngles.y;
+        float oppositeLookAngle = (adjacentLookAngle + 180f) % 360f;
+
+        float yRotation = Mathf.Abs(_context.PlayerCamera.GetYRotation());
+        if(yRotation >= oppositeLookAngle - CLAMP_ANGLE && yRotation <= oppositeLookAngle + CLAMP_ANGLE)
+        {
+            adjacentLookAngle = oppositeLookAngle;
+        }
+        // Debug.Log("LookAngle: " + adjacentLookAngle + " | Clamp Range: " + (adjacentLookAngle - CLAMP_ANGLE) + ", " + (adjacentLookAngle + CLAMP_ANGLE));
+        int yRotationSign = _context.PlayerCamera.GetYRotation() < 0 ? -1 : 1;
+        float clampBase = adjacentLookAngle * yRotationSign;
+        _context.PlayerCamera.SetHorizontalClamp(clampBase - CLAMP_ANGLE, clampBase + CLAMP_ANGLE);   
     }
 }

--- a/Assets/Scripts/StateMachine/BaseState.cs
+++ b/Assets/Scripts/StateMachine/BaseState.cs
@@ -56,7 +56,7 @@ public abstract class BaseState
         */
         if (isRootState)
         {
-            Debug.Log("Root State switched to: " + newState);
+            Debug.Log("Root State switched to: " + newState.name);
             stateMachine.CurrentState = newState;
         }
         else if (currentSuperState != null)
@@ -66,20 +66,20 @@ public abstract class BaseState
             * substate to change from this one to the new one. Pretty
             * much transfering states.
             */
-            Debug.Log("Sub State switched to: " + newState);
+            Debug.Log("Sub State switched to: " + newState.name);
             currentSuperState.SetSubState(newState);
         }
     }
 
     protected void SetSuperState(BaseState newSuperState) 
     {
-        Debug.Log(this + " setting new Super State: " + newSuperState);
+        Debug.Log(this + " setting new Super State: " + newSuperState.name);
         currentSuperState = newSuperState;
     }
 
     protected void SetSubState(BaseState newSubState) 
     {
-        Debug.Log(this + " setting new Sub State: " + newSubState);
+        Debug.Log(this + " setting new Sub State: " + newSubState.name);
         currentSubState = newSubState;
         newSubState.SetSuperState(this);
     }


### PR DESCRIPTION
**Summary:**

**Wallrun**
- Makes wall running automatic once started (no additional inputs are required to maintain a wall run after the additional side input to start one), reducing execution on player's side
- Applies force to player towards the wall, making it harder for player to side-walk out of a wallrun
- Horizontal camera rotation is clamped, preventing player from accidentally "rotating out" of a wallrun

**Slide**
- Reduces minimum velocity to slide, making it more consistent
- Slide orientation changes are now handled by animations, making transitions and camerawork between states smoother

**Crouch**
- GroundCrouch and AirCrouch orientation changes are now handled by animations, making transitions and camerawork between states smoother (this was way more work than it sounds)
