### PR TITLE
fix: adjust wallrun camera bound

### DIFF
--- a/Assets/Scripts/Player/PlayerCamera.cs
+++ b/Assets/Scripts/Player/PlayerCamera.cs
@@ -8,8 +8,9 @@ public class PlayerCamera : MonoBehaviour
     [Header("Settings")]
     [SerializeField] float mouseSensitivity = 100f;
     [SerializeField] float verticalClamp = 90f;
-    float maxHorizontalClamp = 0f;
-    float minHorizontalClamp = 0f;
+    bool isHorizontallyBounded = false;
+    float clockWiseBound = 0f;
+    float counterClockWiseBound = 0f;
     private float xRotation = 0f;
     private float yRotation = 0f;
 
@@ -27,25 +28,31 @@ public class PlayerCamera : MonoBehaviour
 
         xRotation -= mouseY;
         xRotation = Mathf.Clamp(xRotation, -verticalClamp, verticalClamp);
-
-        yRotation += mouseX;
-        yRotation = (maxHorizontalClamp == minHorizontalClamp) 
-            ? yRotation % 360f 
-            : Mathf.Clamp(yRotation, minHorizontalClamp, maxHorizontalClamp) % 360f;
-        
         transform.localRotation = Quaternion.Euler(xRotation, 0f, 0f);
+        
+        if(isHorizontallyBounded)
+        {
+            if(
+                (mouseX > 0f && yRotation + mouseX >= clockWiseBound) 
+                || (mouseX < 0f && yRotation + mouseX <= counterClockWiseBound)
+            ) return;
+        }
+
+        yRotation += mouseX; // This thing can grow indefinitely. It'll become a god.
         orientation.localRotation = Quaternion.Euler(0f, yRotation, 0f);
     }
 
-    public void SetHorizontalClamp(float min, float max)
+    public void SetHorizontalBounds(float counterClockWise, float clockWise)
     {
-        minHorizontalClamp = min % 360f;
-        maxHorizontalClamp = max % 360f;
+        counterClockWiseBound = counterClockWise;
+        clockWiseBound = clockWise;
+        isHorizontallyBounded = true;
     }
-    public void RemoveHorizontalClamp()
+    public void RemoveHorizontalBounds()
     {
-        minHorizontalClamp = 0;
-        maxHorizontalClamp = 0;
+        counterClockWiseBound = 0;
+        clockWiseBound = 0;
+        isHorizontallyBounded = false;
     }
 
     public float GetYRotation()
@@ -56,5 +63,11 @@ public class PlayerCamera : MonoBehaviour
     public void SetYRotation(float yRotation)
     {
         this.yRotation = yRotation;
+    }
+
+    public void MakeRotationPositive()
+    {
+        if (yRotation >= 0f) return;
+        yRotation = (yRotation + 360f) % 360f;
     }
 }

--- a/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
+++ b/Assets/Scripts/Player/StateMachine/PlayerWallRunState.cs
@@ -15,7 +15,7 @@ public class PlayerWallRunState : PlayerBaseState
         wallNormal = leftHit.collider ? leftHit.normal : rightHit.normal;
         adjacentNormal = Vector3.Cross(wallNormal, Vector3.up).normalized;
 
-        SetClamp();
+        SetBounds();
     }
 
     public override void EnterState(){}
@@ -31,7 +31,7 @@ public class PlayerWallRunState : PlayerBaseState
     }
     public override void ExitState()
     {
-        _context.PlayerCamera.RemoveHorizontalClamp();
+        _context.PlayerCamera.RemoveHorizontalBounds();
     }
     public override void CheckSwitchStates()
     {
@@ -47,6 +47,7 @@ public class PlayerWallRunState : PlayerBaseState
         }
     }
     public override void InitializeSubState(){}
+    
     void WallRun()
     {
         float multiplier = _context.AirMultiplier;
@@ -65,27 +66,28 @@ public class PlayerWallRunState : PlayerBaseState
         rb.AddForce(direction * FORWARD_FORCE, ForceMode.Impulse);
         SwitchState(_factory.AirMove()); 
     }
+    
     void Jump()
     {
         if(_context.PressedJump)
             WallJump(_context.Aim.cameraForward());
     }
 
-    void SetClamp()
+    void SetBounds()
     {
         const float CLAMP_ANGLE = 73f;
-        Quaternion adjacentLookDir = Quaternion.LookRotation(adjacentNormal, Vector3.up);
-        float adjacentLookAngle = adjacentLookDir.eulerAngles.y;
-        float oppositeLookAngle = (adjacentLookAngle + 180f) % 360f;
+        Quaternion adjacentLookDir = Quaternion.LookRotation(adjacentNormal, Vector3.up); // The direction that goes along the wall
+        
+        float yRotation = _context.PlayerCamera.GetYRotation();     // Current camera rotation in world space
+        float adjacentLookAngle = adjacentLookDir.eulerAngles.y;    // The world angle of the direction that goes along the wall in one direction
+        
+        float angleDiff = yRotation - adjacentLookAngle;
+        float halfRotations = Mathf.Round(angleDiff / 180f);        // Used to "rotate" the adjacentLookAngle so that the current camera rotation is within bound range
+        
+        float baseLookAngle = adjacentLookAngle + (halfRotations * 180f); // The "rotated" adjacentLookAngle
+        float clockWiseBound = baseLookAngle + CLAMP_ANGLE;
+        float counterClockWiseBound = baseLookAngle - CLAMP_ANGLE;
 
-        float yRotation = Mathf.Abs(_context.PlayerCamera.GetYRotation());
-        if(yRotation >= oppositeLookAngle - CLAMP_ANGLE && yRotation <= oppositeLookAngle + CLAMP_ANGLE)
-        {
-            adjacentLookAngle = oppositeLookAngle;
-        }
-        // Debug.Log("LookAngle: " + adjacentLookAngle + " | Clamp Range: " + (adjacentLookAngle - CLAMP_ANGLE) + ", " + (adjacentLookAngle + CLAMP_ANGLE));
-        int yRotationSign = _context.PlayerCamera.GetYRotation() < 0 ? -1 : 1;
-        float clampBase = adjacentLookAngle * yRotationSign;
-        _context.PlayerCamera.SetHorizontalClamp(clampBase - CLAMP_ANGLE, clampBase + CLAMP_ANGLE);   
+        _context.PlayerCamera.SetHorizontalBounds(counterClockWiseBound, clockWiseBound);
     }
 }

--- a/Assets/Scripts/StateMachine/BaseState.cs
+++ b/Assets/Scripts/StateMachine/BaseState.cs
@@ -66,20 +66,20 @@ public abstract class BaseState
             * substate to change from this one to the new one. Pretty
             * much transfering states.
             */
-            Debug.Log("Sub State switched to: " + newState.name);
+            // Debug.Log("Sub State switched to: " + newState.name);
             currentSuperState.SetSubState(newState);
         }
     }
 
     protected void SetSuperState(BaseState newSuperState) 
     {
-        Debug.Log(this + " setting new Super State: " + newSuperState.name);
+        // Debug.Log(this + " setting new Super State: " + newSuperState.name);
         currentSuperState = newSuperState;
     }
 
     protected void SetSubState(BaseState newSubState) 
     {
-        Debug.Log(this + " setting new Sub State: " + newSubState.name);
+        // Debug.Log(this + " setting new Sub State: " + newSubState.name);
         currentSubState = newSubState;
         newSubState.SetSuperState(this);
     }


### PR DESCRIPTION
Camera was incorrectly snapping to fit wallrun clamp when player rotated to face a specific angle before starting a wallrun. This PR drops clamping in favor of bounds and fixes the snap.